### PR TITLE
Allow specification of colours indepenent of face

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hrvoje Niksic <hniksic@gmail.com>
 ;; Keywords: hypermedia, extensions
-;; Version: 1.49
+;; Version: 1.50
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Previously, HTML colours were defined based on Emacs faces. We now allow
the specification of colours in a variable.