### PR TITLE
Add Homepage to the package header

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 1997-2003,2005,2006,2009,2011,2012,2014,2017,2018 Hrvoje Niksic
 
 ;; Author: Hrvoje Niksic <hniksic@gmail.com>
+;; Homepage: https://github.com/hniksic/emacs-htmlize
 ;; Keywords: hypermedia, extensions
 ;; Version: 1.55
 


### PR DESCRIPTION
The Homepage/URL header is the suggested way to tell other where a packages lives, and `C-h P` etc will utilize it.