### PR TITLE
[RFC] Add support for functions as face sizes

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -1122,11 +1122,14 @@ If no rgb.txt file is found, return nil."
 
 (defun htmlize-merge-size (merged next)
   ;; Calculate the size of the merge of MERGED and NEXT.
-  (cond ((null merged)     next)
-	((integerp next)   next)
-	((null next)       merged)
-	((floatp merged)   (* merged next))
-	((integerp merged) (round (* merged next)))))
+  (let ((next (if (functionp next)
+                  (apply next '(merged)) next)))
+    (cond ((null merged)     next)
+	  ((integerp next)   next)
+	  ((null next)       merged)
+	  ((floatp merged)   (* merged next))
+	  ((integerp merged) (round (* merged next))))))
+
 
 (defun htmlize-merge-two-faces (merged next)
   (htmlize-copy-attr-if-set


### PR DESCRIPTION
:height can be a function instead of an explicit number, which I rely on in my theme (eg. https://github.com/kunalb/poet/blob/master/poet-theme.el#L207). 

With this change the function is applied on the previous size ("A function value is called with one argument, the height of the underlying face, and returns the height of the new face" -- https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html). I'm not sure if "merged" is the best argument to pass here but I can't think of any alternatives.

Without this change htmlize on a buffer fails with an error around next not being a valid value type.
`htmlize-merge-two-faces: Wrong type argument: number-or-marker-p, (lambda (base) (truncate (* (face-attribute (quote fixed-pitch) :height nil (quote default)) 1.23)))`

Tested by running htmlize-buffer with poet enabled, output seems sane and it doesn't fail.

Bug report: https://github.com/kunalb/poet/issues/15