### PR TITLE
Fixed "Invalid face reference: quote" error.

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -1035,8 +1035,7 @@ If no rgb.txt file is found, return nil."
     (while head
       (let ((inherit (face-attribute (car head) :inherit)))
         (cond ((listp inherit)
-               (setcdr tail (cl-copy-list inherit))
-               (setq tail (last tail)))
+               (setq tail (last inherit)))
               ((eq inherit 'unspecified))
               (t
                (setcdr tail (list inherit))


### PR DESCRIPTION
Hi, I was unable to htmlize a buffer I wanted to.

Got the error "Invalid face reference: quote".

Debugging this code , I found out that the `htmlize-face-size` function was getting an erroneous value when calling `(last tail)` on the tail's cdr created with `(cl-copy-list inherit)`.

I couldn't figure out why exactly, but it seems that `inherit` was not a "proper" list, it was a `cons` (`listp` returns `t` for `cons` anyway)... so it was getting a broken list with a `quote` element inside it.

Hence, I decided to just simplify the code because as far as I can see, the only purpose of this `cond` branch I changed was to set `tail` to the last element of `inherit`... As `inherit` was not even used after that, I think the copy was unnecessary...

I've tested the code after this change on several buffers and it worked every time, so I hope you accept the PR or at least find a better fix from the information here.

By the way, `htmlfontify-buffer` also fails with this error but it seems to use completely different code.

Thanks!