### PR TITLE
Fixes #49. Translate Emacs image types into Mime image types

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -339,6 +339,12 @@ output.")
   "Hook run by `htmlize-file' after htmlizing a file, but before saving it.")
 
 (defvar htmlize-buffer-places)
+
+(defconst htmlize-image-mime-type-alist
+  '((svg . "svg+xml")
+    )
+  "Alist mapping Emacs image types to Mime media types.
+https://www.iana.org/assignments/media-types/media-types.xhtml#image")
 
 ;;; Some cross-Emacs compatibility.
 
@@ -589,10 +595,11 @@ list."
                      (htmlize-attr-escape (file-relative-name file))
                      alt-attr)))
           ((plist-get imgprops :data)
-           (format "<img src=\"data:image/%s;base64,%s\"%s />"
-                   (or (plist-get imgprops :type) "")
-                   (base64-encode-string (plist-get imgprops :data))
-                   alt-attr)))))
+           (let ((image-type (plist-get imgprops :type)))
+             (format "<img src=\"data:image/%s;base64,%s\"%s />"
+                     (or (alist-get image-type htmlize-image-mime-type-alist) image-type "")
+                     (base64-encode-string (plist-get imgprops :data))
+                     alt-attr))))))
 
 (defconst htmlize-ellipsis (propertize "..." 'htmlize-ellipsis t))
 


### PR DESCRIPTION
Try first translating the Emacs image type to Mime image type, try then the original alternatives.