### PR TITLE
Fixes #51. Copy expanded-tab before propertizing.

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -747,6 +747,7 @@ list."
              (let ((display (get-text-property match-pos 'display text))
                    (expanded-tab (aref htmlize-tab-spaces tab-size)))
                (when display
+                 (setq expanded-tab (copy-sequence expanded-tab))
                  (put-text-property 0 tab-size 'display display expanded-tab))
                (push expanded-tab chunks))
              (cl-incf column tab-size)


### PR DESCRIPTION
Here is an alternative way to avoid the duplication of overlay images.

I created this alternative branch for the case that you are concerned about any performance impact that `make-string` could possibly cause.

The function remains exactly the same as long as `expanded-string` is not propertized with a `display` property.
If it is propertized then the string from `htmlize-tab-spaces` which `expanded-tab` points to is first copied and then the copy is propertized. This way `htmlize-tab-spaces` also remains untouched.

I find this branch slightly uglier than [51-remove-htmlize-tab-spaces](https://github.com/TobiasZawada/emacs-htmlize/tree/51-remove-htmlize-tab-spaces) because the resulting code is somewhat more complicated.
But, on the other hand this branch has only minimal changes that just fix the problem and do not change the timing characteristics of the package otherwise. I think it can safely be assumed that display-propertized indentation rarely occurs.

