### PR TITLE
fixup f7cc2af98d - off-by-one error in appending display

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -361,8 +361,8 @@ https://www.iana.org/assignments/media-types/media-types.xhtml#image")
     (setq pos (min pos next-prop))
     ;; Additionally, we include the entire region that specifies the
     ;; `display' property.
-    (when (get-char-property pos 'display)
-      (setq pos (next-single-char-property-change pos 'display nil limit)))
+    (when (get-char-property (1- pos) 'display)
+      (setq pos (next-single-char-property-change (1- pos) 'display nil limit)))
     pos))
 
 


### PR DESCRIPTION
- was testing the following char for a display property when it should test the last char
- fixup f7cc2af98d
- found when htmlizing org-modern which [uses display to add padding](https://github.com/minad/org-modern/blob/1.9/org-modern.el#L481-L483)

### Org-Modern

`* TODO my org-modern item :tag:`
<img width="259" height="21" alt="image" src="https://github.com/user-attachments/assets/27bd0f76-a7f5-4a7a-8932-640a80b43613" />

### Buggy:

`<span class="org-level-1"><span class="hl-line">&#9660;  T</span></span><span class="org-modern-todo"><span class="hl-line">ODO </span>`

<img width="285" height="32" alt="image" src="https://github.com/user-attachments/assets/c5e117cc-4a2f-455d-9e93-c907b5cc0757" />

### Fixed:

`<span class="org-level-1"><span class="hl-line">&#9660; </span></span><span class="org-modern-todo"><span class="hl-line"> TODO </span>`

<img width="285" height="32" alt="image" src="https://github.com/user-attachments/assets/69ef9d08-da0d-47b3-9786-fad05d869a7f" />
