### PR TITLE
Fix for org-rainbow-tags (12-digit color codes)

### DIFF
--- a/htmlize.el
+++ b/htmlize.el
@@ -945,14 +945,14 @@ If no rgb.txt file is found, return nil."
          (size-chan (cond ((eq len-col 12) 4) ;; if length of color is 12, then 3 channels of size 4
                           ((eq len-col 16) 4) ;; if length of color is 16, then 3 channels + alpha of size 4
                           (t (/ len-col 3)))) ;; assume 3 channels for arbitrary sizes of size N/3
-         (new-color "")
+         (new-color "#")
          (i 0))
     (while (< i len-col)
       (let ((start i)
             (end (+ i 2))) ;; normal channel sizes are 2 digit hexes
         (setq new-color (concat new-color (substring xcolor start end))
               i (+ i size-chan))))
-    (concat "#" new-color)))
+    new-color))
 
 ;; Convert COLOR to the #RRGGBB string.  If COLOR is already in that
 ;; format, it's left unchanged.


### PR DESCRIPTION
[org-rainbow-tags](https://github.com/KaratasFurkan/org-rainbow-tags) is a package which autogenerates some nice looking color overlays for org-mode tag names.

However, face names use strings instead of symbols (causing `htmlize-face-to-fstruct` to detect no color at the face at point), and uses 12-digit color codes which Emacs renders fine but CSS does not (hence the fix to `htmlize-color-to-rgb`).

This PR adds a general fix for quoted face names, and truncates long color hexes into CSS colors.


```
htmlize.el: htmlize-color-to-rgb, htmlize-face-to-fstruct, htmlize--truncate-hex

Added some small fixes relating org-rainbow-tags which uses strings for tagnames instead of symbols, and 12-digit color codes.

* htmlize-face-to-fstruct: Sets string faces to symbols
* htmlize-color-to-rgb: Update the regex for readability, truncate hex if longer than 9 characters, assuming 8-digit rrggbbaa css colors are fine.
* htmlize--truncate-hex: New function that converts an arbitrary long color hex to a normal 6 digit hex
```
